### PR TITLE
Qol

### DIFF
--- a/client/src/components/DrawCanvas.js
+++ b/client/src/components/DrawCanvas.js
@@ -153,9 +153,10 @@ export default class DrawCanvas extends Component {
   }
 
   handleTouchEnd = (event) => {
-    if (event.touches.length) {
-      this.handleMouseUp(event.touches[0]);
-    }
+    // touchend events have no touch list.
+    this.handleMouseUp(event);
+    // When the touch event doesn't move, mouseup would be (double) fired next.
+    event.preventDefault();
   }
 
   handleTouchMove = (event) => {


### PR DESCRIPTION
The `touchend` event handler was incorrectly written to never do anything. Unfortunately, this caused no visual issues with drawing. However, the newly introduced undo/redo stack relied on `touchend`/`mouseup` to commit a change to the undo stack. Without `touchend`, the undo stack was never committed to, so undo would always restore the default state (a blank image).