### PR TITLE
Features for large parties

### DIFF
--- a/client/src/components/GameComponent.js
+++ b/client/src/components/GameComponent.js
@@ -67,12 +67,29 @@ export default class GameComponent extends Component {
       this.setState({
         mainView: 'SPECTATE_VIEW',
       });
+    } else if (this.state.settings.maxRounds &&
+        this.state.settings.maxRounds < this.calculateCurrentRoundNumber()) {
+      this.setState({
+        mainView: 'SPECTATE_VIEW',
+      });
     } else {
       this.setState({
         mainView: 'GAME_PHASE_VIEW',
         chainID: nextChain,
       });
     }
+  }
+
+  // Linearly calculate round number using userID and chainID.
+  // 
+  calculateCurrentRoundNumber = () => {
+    let roundNumber = 1;
+    let chainID = this.state.userID;
+    while (chainID !== undefined && chainID != this.state.chainID) {
+      ++roundNumber;
+      chainID = this.state.settings.order[chainID];
+    }
+    return roundNumber;
   }
 
   /***************************************************************************

--- a/client/src/components/RoomComponent.js
+++ b/client/src/components/RoomComponent.js
@@ -9,11 +9,12 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Paper from '@material-ui/core/Paper';
 import TextField from '@material-ui/core/TextField';
+import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
 // Icons.
-import UserActive from '@material-ui/icons/AccountBox';
-import UserInactive from '@material-ui/icons/AccountBox';
+import UserActive from '@material-ui/icons/Check';
+import UserInactive from '@material-ui/icons/Close';
 
 const styles = {
   layout: {
@@ -75,6 +76,14 @@ export default class RoomComponent extends Component {
           sharedState: snapshot.val()
         });
       }
+    });
+
+    // Register a listener for the list of players still in game.
+    this.activePlayersRef = this.state.roomRef.child('game').child('activePlayers');
+    this.activePlayersRef.on('value', (snapshot) => {
+      this.setState({
+        activePlayers: snapshot.val()
+      });
     });
   }
 
@@ -151,13 +160,30 @@ export default class RoomComponent extends Component {
    * Render                                                                  *
    ***************************************************************************/
 
+  getUserIcon = (userInGame) => {
+    if (userInGame) {
+      return (
+        <Tooltip title='In Game'>
+          <UserInactive />
+        </Tooltip>
+      );
+    } else {
+      return (
+        <Tooltip title='Ready'>
+          <UserActive />
+        </Tooltip>
+      );
+    }
+  }
+
   getUserListItems = () => {
     if (this.state.users && Object.keys(this.state.users).length) {
       return Object.keys(this.state.users).map((key, index) => {
+        let userInGame = this.state.activePlayers && key in this.state.activePlayers;
         return (
           <ListItem key={key}>
             <ListItemIcon>
-              <UserActive />
+              {this.getUserIcon(userInGame)}
             </ListItemIcon>
             <ListItemText
               primary={this.state.users[key].nickName}

--- a/client/src/components/RoomComponent.js
+++ b/client/src/components/RoomComponent.js
@@ -190,9 +190,9 @@ export default class RoomComponent extends Component {
           <div style={styles.settingsContainer}>
             <div style={styles.settingsRow}>
               <TextField
-                label='Round Theme (unused)'
-                value={this.state.sharedState.theme || ''}
-                onChange={(event) => this.setState({sharedState: {theme: event.target.value}})}
+                label={'Max rounds (default ' + Object.keys(this.state.users).length + ')'}
+                value={this.state.sharedState.maxRounds || ''}
+                onChange={(event) => this.setState({sharedState: {maxRounds: event.target.value}})}
                 style={styles.textField}
               />
               <TextField


### PR DESCRIPTION
Add a max rounds setting. By default, the game ends when all players have contributed to all other players' chains. This results in longer games for larger parties, which may not be as enjoyable. Setting a limit on the max rounds allows large parties to enjoy shorter games.

Visually indicate which players are still in game. This is useful for large parties looking to restart a game, who may need to call out stragglers that are still reviewing the chain.